### PR TITLE
fixed showOngoing toggled on initially when underlying value is falsey.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-ics",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-ics",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "MIT",
       "dependencies": {
         "moment-timezone": "^0.5.43",

--- a/src/settings/ICSSettingsTab.ts
+++ b/src/settings/ICSSettingsTab.ts
@@ -373,7 +373,7 @@ class SettingsModal extends Modal {
       .setName('Show Ongoing')
       .setDesc('Display multi-day events that include target date')
       .addToggle(toggle => toggle
-        .setValue(this.format.showOngoing || true) // Use the new property
+        .setValue(this.format.showOngoing || false) // Use the new property
         .onChange(value => {
           this.format.showOngoing = value; // Set the new property
         }));


### PR DESCRIPTION
Closes #118 
(@muness - sorry for introducing a bug 🫢)