### PR TITLE
added download notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-ics",
-  "version": "1.6.5",
+  "version": "1.6.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-ics",
-      "version": "1.6.5",
+      "version": "1.6.5.1",
       "license": "MIT",
       "dependencies": {
         "moment-timezone": "^0.5.43",

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,10 +68,20 @@ export default class ICSPlugin extends Plugin {
   }
 
   async getEvents(date: string): Promise<IEvent[]> {
+    if (
+      this.data.format.notificationLevel === 'light' ||
+      this.data.format.notificationLevel === 'verbose'
+    ) {
+      new Notice('ICS: Downloading calendars...');
+    }
+    
     let events: IEvent[] = [];
     let errorMessages: string[] = []; // To store error messages
 
     for (const calendar in this.data.calendars) {
+      if (this.data.format.notificationLevel === 'verbose') {
+        new Notice(`ICS: Downloading '${calendar}'...`);
+      }
       const calendarSetting = this.data.calendars[calendar];
       let icsArray: any[] = [];
 
@@ -135,10 +145,17 @@ export default class ICSPlugin extends Plugin {
 
     // Notify the user if any errors were encountered
     if (errorMessages.length > 0) {
-      const message = `Encountered ${errorMessages.length} error(s) while processing calendars:\n\n${errorMessages.join('\n')}\nSee console for details.`;
+      const message = `ICS: Encountered ${errorMessages.length} error(s) while processing calendars:\n\n${errorMessages.join('\n')}\nSee console for details.`;
       new Notice(message);
     }
 
+    if (
+      this.data.format.notificationLevel === 'light' ||
+      this.data.format.notificationLevel === 'verbose'
+    ) {
+      new Notice('ICS: Calendar download finished!');
+    }
+    
     return events;
   }
 

--- a/src/settings/ICSSettings.ts
+++ b/src/settings/ICSSettings.ts
@@ -2,6 +2,7 @@ export interface ICSSettings {
     format: {
         timeFormat: string
         dataViewSyntax: boolean,
+        notificationLevel: 'none' | 'light' | 'verbose';
     },
     calendars: Record < string, Calendar > ;
 }
@@ -38,6 +39,7 @@ export const DEFAULT_SETTINGS: ICSSettings = {
     format: {
         timeFormat: "HH:mm",
         dataViewSyntax: false,
+        notificationLevel: 'none'
     },
     calendars: {
     }

--- a/src/settings/ICSSettingsTab.ts
+++ b/src/settings/ICSSettingsTab.ts
@@ -74,6 +74,28 @@ export default class ICSSettingsTab extends PluginSettingTab {
     return descEl;
   }
 
+  private notificationLevelDescription(): DocumentFragment {
+    const descEl = document.createDocumentFragment();
+    descEl.appendText('Choose how many notifications you want ICS to display.');
+    descEl.appendChild(document.createElement('br'));
+    descEl.appendChild(document.createElement('br'));
+
+    const noneB = descEl.appendChild(document.createElement('b'));
+    noneB.appendText('None: ');
+    descEl.appendText('No notifications.');
+
+    descEl.appendChild(document.createElement('br'));
+    const lightB = descEl.appendChild(document.createElement('b'));
+    lightB.appendText('Light: ');
+    descEl.appendText('When starting and finishing overall download.');
+    descEl.appendChild(document.createElement('br'));
+
+    const verboseB = descEl.appendChild(document.createElement('b'));
+    verboseB.appendText('Verbose: ');
+    descEl.appendText('Overall + per calendar download notifications.');
+    return descEl;
+  }
+
   display(): void {
     let {
       containerEl
@@ -185,6 +207,22 @@ export default class ICSSettingsTab extends PluginSettingTab {
           this.plugin.data.format.dataViewSyntax = v;
           await this.plugin.saveSettings();
         }));
+
+    const notificationLevelSetting = new Setting(containerEl)
+      .setName('Notification Level')
+      .setDesc(this.notificationLevelDescription())
+      .addDropdown((component) => {
+        component
+            .addOption('none', 'None')
+            .addOption('light', 'Light')
+            .addOption('verbose', 'Verbose')
+          .setValue(this.plugin.data.format.notificationLevel || 'none')
+          .onChange(async (v) => {
+              this.plugin.data.format.notificationLevel = v as 'none' | 'light' | 'verbose';
+              await this.plugin.saveSettings();
+            });
+        });
+  
 
     // Sponsor link - Thank you!
     const divSponsor = containerEl.createDiv();


### PR DESCRIPTION
This aims to close #102.

I hope this is what you were after - the none/light/verbose was inspired by [Remotely Save](https://github.com/remotely-save/remotely-save). Marking this as a draft, happy to adapt if you had something else in mind.