### PR TITLE
Ensure recurrent flag is set correctly

### DIFF
--- a/src/icalUtils.ts
+++ b/src/icalUtils.ts
@@ -53,6 +53,8 @@ function processRecurrenceOverrides(event: any, dayToMatch: string, excludedDate
       continue;
     }
 
+    recurrence.recurrent = true;
+
     // Check if this override matches the dayToMatch
     if (moment(recurrence.start).isSame(dayToMatch, "day")) {
       console.debug(`Adding recurring event with override: ${recurrence.summary} on ${recurrenceMoment.format('YYYY-MM-DD')}`);


### PR DESCRIPTION
Fixes the `recurrent` flag not being set in the case of recurrent overrides.

`processRecurringRules()` correctly sets the `recurrent` flag, however this flag had been missed in `processRecurrenceOverrides()`